### PR TITLE
Custom Map Props

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ import { MessageBox } from 'react-chat-elements'
 | ---- | ---- | ---- | ---- |
 | id | i (index) | string | message box id |
 | position | left | string | message box position |
-| type | text | string | message type (text, photo, file) |
+| type | text | string | message type (text, photo, file, location, spotify) |
 | text | none | string | message text |
 | title | none | string | message title |
 | titleColor | none | string(color) | message title color |
@@ -109,7 +109,7 @@ import { MessageBox } from 'react-chat-elements'
 | onTitleClick | none | function | message title on click event |
 | onForwardClick | none | function | message forward on click event |
 | forwarded | none | boolean | message forward icon |
-| statu | none | string | message statu info (waiting, sent, received, read) |
+| status | none | string | message status info (waiting, sent, received, read) |
 | notch | true | boolean | message box notch |
 | avatar | none | url | message box avatar url |
 | renderAddCmp | none | function (component) | adding custom components to message box |

--- a/example/App.js
+++ b/example/App.js
@@ -62,19 +62,19 @@ export class App extends Component {
         switch (type) {
             case 'message':
                 var type = this.token();
-                var statu = 'waiting';
+                var status = 'waiting';
                 switch (type) {
                     case 0:
                         type = 'photo';
-                        statu = 'sent';
+                        status = 'sent';
                         break;
                     case 1:
                         type = 'file';
-                        statu = 'sent';
+                        status = 'sent';
                         break;
                     case 2:
                         type = 'system';
-                        statu = 'received';
+                        status = 'received';
                         break;
                     case 3:
                         type = 'location';
@@ -84,7 +84,7 @@ export class App extends Component {
                         break;
                     default:
                         type = 'text';
-                        statu = 'read';
+                        status = 'read';
                         break;
                 }
 
@@ -108,7 +108,7 @@ export class App extends Component {
                         latitude: '37.773972',
                         longitude: '-122.431297',
                     },
-                    statu: statu,
+                    status: status,
                     date: new Date(),
                     dateString: moment(new Date()).format('HH:mm'),
                     avatar: `data:image/png;base64,${this.photo()}`,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-chat-elements",
-  "version": "0.6.1",
+  "version": "0.7.0",
   "description": "Reactjs chat components",
   "author": "Avare Kodcu <abdurrahmaneker58@gmail.com>",
   "main": "dist/main.js",

--- a/src/LocationMessage/LocationMessage.css
+++ b/src/LocationMessage/LocationMessage.css
@@ -1,7 +1,6 @@
 .rce-mbox-location {
     position: relative;
     width: 250px;
-    height: 150px;
     overflow: hidden;
     display: flex;
     align-items: center;
@@ -14,4 +13,10 @@
 
 .rce-mbox-location-img {
     width: 100%;
+}
+
+.rce-mbox-location-text {
+  width: 250px;
+  margin-left: -6px;
+  margin-right: -6px;
 }

--- a/src/LocationMessage/LocationMessage.js
+++ b/src/LocationMessage/LocationMessage.js
@@ -16,12 +16,6 @@ export class LocationMessage extends Component {
         this.className = this.className.bind(this);
     }
 
-    staticURL() {
-        var center = this.props.data;
-
-        return STATIC_URL.replace('');
-    }
-
     buildURL(url) {
         var center = this.props.data;
 

--- a/src/LocationMessage/LocationMessage.js
+++ b/src/LocationMessage/LocationMessage.js
@@ -13,6 +13,7 @@ export class LocationMessage extends Component {
         super(props);
 
         this.staticURL = this.staticURL.bind(this);
+        this.className = this.className.bind(this);
     }
 
     staticURL() {
@@ -29,22 +30,41 @@ export class LocationMessage extends Component {
                   .replace('MARKER_COLOR', this.props.markerColor || DEFAULT_MARKER_COLOR)
                   .replace('ZOOM', this.props.zoom || DEFAULT_ZOOM_LEVEL)
                   .replace('KEY', this.props.apiKey);
+
+        
+    }
+
+    className() {
+      var className = classNames('rce-mbox-location', this.props.className);
+
+      if (this.props.text && this.props.text.length > 0) {
+        className = classNames(className, 'rce-mbox-location-has-text');
+      }
+
+      return className;
     }
 
     render() {
         return (
-            <a
-                onClick={this.props.onOpen}
-                target={this.props.target}
-                href={this.props.href || this.props.src || this.buildURL(MAP_URL)}
-                className={classNames('rce-mbox-location', this.props.className)}>
-                <img
-                    className='rce-mbox-location-img'
-                    src={
-                        this.props.src ||
-                        this.buildURL(STATIC_URL)
-                    }/>
-            </a>
+            <div>
+                <a
+                    onClick={this.props.onOpen}
+                    target={this.props.target}
+                    href={this.props.href || this.props.src || this.buildURL(MAP_URL)}
+                    className={this.className()}>
+                        <img className='rce-mbox-location-img'
+                             src={
+                                 this.props.src ||
+                                 this.buildURL(STATIC_URL)
+                             }/>
+                </a>
+                {
+                    this.props.text &&
+                    <div className="rce-mbox-text rce-mbox-location-text">
+                        {this.props.text}
+                    </div>
+                }
+            </div>
         );
     }
 }

--- a/src/LocationMessage/LocationMessage.js
+++ b/src/LocationMessage/LocationMessage.js
@@ -12,7 +12,6 @@ export class LocationMessage extends Component {
     constructor(props) {
         super(props);
 
-        this.staticURL = this.staticURL.bind(this);
         this.className = this.className.bind(this);
     }
 
@@ -24,8 +23,6 @@ export class LocationMessage extends Component {
                   .replace('MARKER_COLOR', this.props.markerColor || DEFAULT_MARKER_COLOR)
                   .replace('ZOOM', this.props.zoom || DEFAULT_ZOOM_LEVEL)
                   .replace('KEY', this.props.apiKey);
-
-        
     }
 
     className() {

--- a/src/LocationMessage/LocationMessage.js
+++ b/src/LocationMessage/LocationMessage.js
@@ -3,19 +3,32 @@ import './LocationMessage.css';
 
 const classNames = require('classnames');
 
+const STATIC_URL = 'https://maps.googleapis.com/maps/api/staticmap?markers=color:MARKER_COLOR|LATITUDE,LONGITUDE&zoom=ZOOM&size=270x200&scale=2&key=KEY';
+const MAP_URL = 'https://www.google.com/maps/search/?api=1&query=LATITUDE,LONGITUDE&zoom=ZOOM';
+const DEFAULT_MARKER_COLOR = 'red';
+const DEFAULT_ZOOM_LEVEL = 14;
+
 export class LocationMessage extends Component {
     constructor(props) {
         super(props);
 
-        const {
-            latitude,
-            longitude,
-        } = this.props.data || {};
+        this.staticURL = this.staticURL.bind(this);
+    }
 
-        var key = this.props.apiKey ? ('&key=' + this.props.apiKey): '';
-        this.state = {
-            url: 'https://maps.googleapis.com/maps/api/staticmap?markers=color:red|'+latitude+','+longitude+'&zoom=14&size=270x200&scale=2' + key,
-        };
+    staticURL() {
+        var center = this.props.data;
+
+        return STATIC_URL.replace('');
+    }
+
+    buildURL(url) {
+        var center = this.props.data;
+
+        return url.replace('LATITUDE', center.latitude)
+                  .replace('LONGITUDE', center.longitude)
+                  .replace('MARKER_COLOR', this.props.markerColor || DEFAULT_MARKER_COLOR)
+                  .replace('ZOOM', this.props.zoom || DEFAULT_ZOOM_LEVEL)
+                  .replace('KEY', this.props.apiKey);
     }
 
     render() {
@@ -23,13 +36,13 @@ export class LocationMessage extends Component {
             <a
                 onClick={this.props.onOpen}
                 target={this.props.target}
-                href={this.props.href || this.props.src || this.state.url}
+                href={this.props.href || this.props.src || this.buildURL(MAP_URL)}
                 className={classNames('rce-mbox-location', this.props.className)}>
                 <img
                     className='rce-mbox-location-img'
                     src={
                         this.props.src ||
-                        this.state.url
+                        this.buildURL(STATIC_URL)
                     }/>
             </a>
         );
@@ -38,7 +51,7 @@ export class LocationMessage extends Component {
 
 LocationMessage.defaultProps = {
     target: '_blank',
-    apiKey: null,
+    apiKey: '',
 }
 
 export default LocationMessage;

--- a/src/MessageBox/MessageBox.css
+++ b/src/MessageBox/MessageBox.css
@@ -159,7 +159,7 @@
     margin-bottom: 5px;
 }
 
-.rce-mbox-statu {
+.rce-mbox-status {
     margin-left: 3px;
     font-size: 15px;
 }

--- a/src/MessageBox/MessageBox.js
+++ b/src/MessageBox/MessageBox.js
@@ -23,7 +23,7 @@ const classNames = require('classnames');
 export class MessageBox extends Component {
     render() {
         var positionCls = classNames('rce-mbox', { 'rce-mbox-right': this.props.position === 'right' });
-        var thatAbsoluteTime = this.props.type !== 'text' && this.props.type !== 'file';
+        var thatAbsoluteTime = this.props.type !== 'text' && this.props.type !== 'file' && !(this.props.type === 'location' && this.props.text);
 
         return (
             <div
@@ -96,6 +96,7 @@ export class MessageBox extends Component {
                                         src={this.props.src}
                                         zoom={this.props.zoom}
                                         markerColor={this.props.markerColor} />
+                                        text={this.props.text} />
                                 }
 
                                 {
@@ -139,25 +140,25 @@ export class MessageBox extends Component {
                                         )
                                     }
                                     {
-                                        this.props.statu &&
-                                        <span className='rce-mbox-statu'>
+                                        this.props.status &&
+                                        <span className='rce-mbox-status'>
                                             {
-                                                this.props.statu === 'waiting' &&
+                                                this.props.status === 'waiting' &&
                                                 <MdIosTime />
                                             }
 
                                             {
-                                                this.props.statu === 'sent' &&
+                                                this.props.status === 'sent' &&
                                                 <MdCheck />
                                             }
 
                                             {
-                                                this.props.statu === 'received' &&
+                                                this.props.status === 'received' &&
                                                 <IoDoneAll />
                                             }
 
                                             {
-                                                this.props.statu === 'read' &&
+                                                this.props.status === 'read' &&
                                                 <IoDoneAll color='#4FC3F7'/>
                                             }
                                         </span>
@@ -207,7 +208,7 @@ MessageBox.defaultProps = {
     onOpen: null,
     onDownload: null,
     forwarded: false,
-    statu: null,
+    status: null,
     dateString: null,
     notch: true,
     avatar: null,

--- a/src/MessageBox/MessageBox.js
+++ b/src/MessageBox/MessageBox.js
@@ -95,7 +95,7 @@ export class MessageBox extends Component {
                                         apiKey={this.props.apiKey}
                                         src={this.props.src}
                                         zoom={this.props.zoom}
-                                        markerColor={this.props.markerColor} />
+                                        markerColor={this.props.markerColor}
                                         text={this.props.text} />
                                 }
 

--- a/src/MessageBox/MessageBox.js
+++ b/src/MessageBox/MessageBox.js
@@ -93,7 +93,9 @@ export class MessageBox extends Component {
                                         target={this.props.target}
                                         href={this.props.href}
                                         apiKey={this.props.apiKey}
-                                        src={this.props.src} />
+                                        src={this.props.src}
+                                        zoom={this.props.zoom}
+                                        markerColor={this.props.markerColor} />
                                 }
 
                                 {

--- a/src/MessageBox/__tests__/MessageBox.js
+++ b/src/MessageBox/__tests__/MessageBox.js
@@ -5,7 +5,7 @@ import MessageBox from '../MessageBox';
 
 describe('MessageBox component', () => {
   it('should render without issues', () => {
-    const component = shallow(<MessageBox statu='read'/>);
+    const component = shallow(<MessageBox status='read'/>);
 
     expect(component.length).toBe(1);
     expect(toJson(component)).toMatchSnapshot();

--- a/src/MessageBox/__tests__/__snapshots__/MessageBox.js.snap
+++ b/src/MessageBox/__tests__/__snapshots__/MessageBox.js.snap
@@ -19,7 +19,7 @@ exports[`MessageBox component should render without issues 1`] = `
       >
         a few seconds ago
         <span
-          className="rce-mbox-statu"
+          className="rce-mbox-status"
         >
           <IoAndroidDoneAll
             color="#4FC3F7"


### PR DESCRIPTION
* Custom marker colors
* Custom zoom level
* Click through to Google Map rather than static image.
  * This supports on device apps.
* Update documentation to show extra MessageBox Options
* Renate `statu` variable to be `status`.
* Bump version number due to breaking change on `statu`
* Allows for text to be passed through to a location message
  * Adjusts styling based on if text is present or not.
  * Adjusts timestamps based on if text is present or not.

![screen shot 2017-10-26 at 15 52 36](https://user-images.githubusercontent.com/120821/32060088-ba515c70-ba65-11e7-8f48-46ff44cdac3c.png)
