### PR TITLE
Changed dependency of react-progressbar

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "classnames": "^2.2.5",
     "moment": "^2.18.1",
     "react-icons": "^2.2.5",
-    "react-progressbar.js": "^0.2.0",
+    "react-progress-bar.js": "^0.2.0-dev",
     "react-spinkit": "^3.0.0"
   }
 }

--- a/src/FileMessage/FileMessage.js
+++ b/src/FileMessage/FileMessage.js
@@ -4,7 +4,7 @@ import './FileMessage.css';
 import FaCloudDownload from 'react-icons/lib/fa/cloud-download';
 import FaFile from 'react-icons/lib/fa/file';
 
-const ProgressBar = require('react-progressbar.js');
+const ProgressBar = require('react-progress-bar.js');
 const Circle = ProgressBar.Circle;
 
 export class FileMessage extends Component {

--- a/src/PhotoMessage/PhotoMessage.js
+++ b/src/PhotoMessage/PhotoMessage.js
@@ -4,7 +4,7 @@ import './PhotoMessage.css';
 
 import FaCloudDownload from 'react-icons/lib/fa/cloud-download';
 
-const ProgressBar = require('react-progressbar.js');
+const ProgressBar = require('react-progress-bar.js');
 const Circle = ProgressBar.Circle;
 
 export class PhotoMessage extends Component {


### PR DESCRIPTION
Changed dependency of react-progressbar to react-progress-bar to allow for React 16 projects to work.

Really like the library so far. Great job! Was looking into to start using it with our project, but needed change for working with React 16. Still new to doing PR's on github, hope this was right ;)