### PR TITLE
Add message focus feature to MessageList.

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,8 @@ import { MessageBox } from 'react-chat-elements'
 | avatar | none | url | message box avatar url |
 | renderAddCmp | none | function (component) | adding custom components to message box |
 | copiableDate | false | boolean | message box date text copiable |
-| messageFocus | false | boolean | used in message focus feature in MessageList component, makes style of the component focused |
+| focus | false | boolean | used in message focus feature in MessageList component, makes style of the component focused |
+| onMessageFocused | none | function | makes focus value false after the message becomes focus |
 
 
 ## SystemMessage Component
@@ -205,9 +206,6 @@ import { MessageList } from 'react-chat-elements'
 | downButtonBadge | none | boolean | message list downButton badge content |
 | onDownButtonClick | none | function | message list onDownButtonClick |
 | onContextMenu | none | function | message list item onContextMenu event, gets 3 parameters: message item, index of item, event |
-| focusedMessage | none | string | id of a message to focus on, this prop makes the MessageList scroll into MessageBox item of given message id |
-| scrollBlock | 'center' | string | used in scroll into focusedMessage as value of block property in parameter of scrollIntoView function |
-
 
 ## ChatList Component
 

--- a/README.md
+++ b/README.md
@@ -145,6 +145,7 @@ import { MessageBox } from 'react-chat-elements'
 | avatar | none | url | message box avatar url |
 | renderAddCmp | none | function (component) | adding custom components to message box |
 | copiableDate | false | boolean | message box date text copiable |
+| messageFocus | false | boolean | used in message focus feature in MessageList component, makes style of the component focused |
 
 
 ## SystemMessage Component
@@ -204,6 +205,9 @@ import { MessageList } from 'react-chat-elements'
 | downButtonBadge | none | boolean | message list downButton badge content |
 | onDownButtonClick | none | function | message list onDownButtonClick |
 | onContextMenu | none | function | message list item onContextMenu event, gets 3 parameters: message item, index of item, event |
+| focusedMessage | none | string | id of a message to focus on, this prop makes the MessageList scroll into MessageBox item of given message id |
+| scrollBlock | 'center' | string | used in scroll into focusedMessage as value of block property in parameter of scrollIntoView function |
+
 
 ## ChatList Component
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-chat-elements",
-  "version": "10.5.0",
+  "version": "10.6.0",
   "description": "Reactjs chat components",
   "author": "Avare Kodcu <abdurrahmaneker58@gmail.com>",
   "main": "dist/main.js",

--- a/src/MessageBox/MessageBox.css
+++ b/src/MessageBox/MessageBox.css
@@ -65,8 +65,8 @@
 }
 
 .rce-mbox.message-focus {
-    animation-iteration-count: 4;
-    -webkit-animation-iteration-count: 5;
+    animation-iteration-count: 2;
+    -webkit-animation-iteration-count: 2;
     -webkit-animation-duration: 1s;
     animation-name: message-box-default-focus;
     animation-duration: 1s;
@@ -92,8 +92,8 @@
 }
 
 .rce-mbox.rce-mbox-right.message-focus {
-    animation-iteration-count: 4;
-    -webkit-animation-iteration-count: 5;
+    animation-iteration-count: 2;
+    -webkit-animation-iteration-count: 2;
     -webkit-animation-duration: 1s;
     animation-name: message-box-right-focus;
     animation-duration: 1s;
@@ -161,8 +161,8 @@
 }
 
 .rce-mbox-right-notch.message-focus {
-    animation-iteration-count: 4;
-    -webkit-animation-iteration-count: 5;
+    animation-iteration-count: 2;
+    -webkit-animation-iteration-count: 2;
     -webkit-animation-duration: 1s;
     animation-name: message-right-notch-focus;
     animation-duration: 1s;
@@ -183,8 +183,8 @@
 }
 
 .rce-mbox-left-notch.message-focus {
-    animation-iteration-count: 4;
-    -webkit-animation-iteration-count: 5;
+    animation-iteration-count: 2;
+    -webkit-animation-iteration-count: 2;
     -webkit-animation-duration: 1s;
     animation-name: message-left-notch-focus;
     animation-duration: 1s;

--- a/src/MessageBox/MessageBox.css
+++ b/src/MessageBox/MessageBox.css
@@ -64,6 +64,19 @@
     min-width: 140px;
 }
 
+.rce-mbox.message-focus {
+    animation-iteration-count: 4;
+    -webkit-animation-iteration-count: 5;
+    -webkit-animation-duration: 1s;
+    animation-name: message-box-default-focus;
+    animation-duration: 1s;
+}
+
+@-webkit-keyframes message-box-default-focus {
+    from {background-color: #fff;}
+    to {background-color: #dfdfdf;}
+}
+
 .rce-mbox-body {
     margin: 0;
     padding: 0;
@@ -76,6 +89,19 @@
     margin-right: 20px;
     border-top-right-radius: 0px;
     border-top-left-radius: 5px;
+}
+
+.rce-mbox.rce-mbox-right.message-focus {
+    animation-iteration-count: 4;
+    -webkit-animation-iteration-count: 5;
+    -webkit-animation-duration: 1s;
+    animation-name: message-box-right-focus;
+    animation-duration: 1s;
+}
+
+@-webkit-keyframes message-box-right-focus {
+    from {background-color: #d4f1fb;}
+    to {background-color: #b8dae6;}
 }
 
 .rce-mbox-text {
@@ -134,6 +160,19 @@
     filter: drop-shadow( 2px 0px 1px rgba(0, 0, 0, .2));
 }
 
+.rce-mbox-right-notch.message-focus {
+    animation-iteration-count: 4;
+    -webkit-animation-iteration-count: 5;
+    -webkit-animation-duration: 1s;
+    animation-name: message-right-notch-focus;
+    animation-duration: 1s;
+}
+
+@-webkit-keyframes message-right-notch-focus {
+    from {fill: #d4f1fb;}
+    to {fill: #b8dae6;}
+}
+
 .rce-mbox-left-notch {
     position: absolute;
     left: -14px;
@@ -141,6 +180,19 @@
     width: 15px;
     height: 15px;
     fill: white;
+}
+
+.rce-mbox-left-notch.message-focus {
+    animation-iteration-count: 4;
+    -webkit-animation-iteration-count: 5;
+    -webkit-animation-duration: 1s;
+    animation-name: message-left-notch-focus;
+    animation-duration: 1s;
+}
+
+@-webkit-keyframes message-left-notch-focus {
+    from {fill: #fff;}
+    to {fill: #dfdfdf;}
 }
 
 .rce-mbox-title {

--- a/src/MessageBox/MessageBox.js
+++ b/src/MessageBox/MessageBox.js
@@ -23,6 +23,19 @@ import {
 import classNames from 'classnames';
 
 export class MessageBox extends Component {
+    componentWillReceiveProps(nextProps) {
+        if (nextProps.focus !== this.props.focus && nextProps.focus === true) {
+            if (this.refs['message']) {
+                this.refs['message'].scrollIntoView({
+                    block: "center",
+                    behavior: 'smooth'
+                })
+
+                this.props.onMessageFocused(nextProps);
+            }
+        }
+    }
+
     render() {
         var positionCls = classNames('rce-mbox', { 'rce-mbox-right': this.props.position === 'right' });
         var thatAbsoluteTime = this.props.type !== 'text' && this.props.type !== 'file' && !(this.props.type === 'location' && this.props.text);
@@ -35,6 +48,7 @@ export class MessageBox extends Component {
 
         return (
             <div
+                ref='message'
                 className={classNames('rce-container-mbox', this.props.className)}
                 onClick={this.props.onClick}>
                 {
@@ -51,7 +65,7 @@ export class MessageBox extends Component {
                                 positionCls,
                                 {'rce-mbox--clear-padding': thatAbsoluteTime},
                                 {'rce-mbox--clear-notch': !this.props.notch},
-                                { 'message-focus': this.props.messageFocus},
+                                { 'message-focus': this.props.focus},
                             )}>
                             <div
                                 className='rce-mbox-body'
@@ -190,7 +204,7 @@ export class MessageBox extends Component {
                                 (this.props.position === 'right' ?
                                     <svg className={classNames(
                                         "rce-mbox-right-notch",
-                                        { 'message-focus': this.props.messageFocus},
+                                        { 'message-focus': this.props.focus},
                                     )} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20">
                                         <path d="M0 0v20L20 0" />
                                     </svg>
@@ -198,7 +212,7 @@ export class MessageBox extends Component {
                                     <div>
                                         <svg className={classNames(
                                                 "rce-mbox-left-notch",
-                                                { 'message-focus': this.props.messageFocus},
+                                                { 'message-focus': this.props.focus},
                                             )} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20">
                                             <defs>
                                                 <filter id="filter1" x="0" y="0">
@@ -241,7 +255,8 @@ MessageBox.defaultProps = {
     renderAddCmp: null,
     copiableDate: false,
     onContextMenu: null,
-    messageFocus: false,
+    focus: false,
+    onMessageFocused: null,
 };
 
 

--- a/src/MessageBox/MessageBox.js
+++ b/src/MessageBox/MessageBox.js
@@ -50,7 +50,8 @@ export class MessageBox extends Component {
                             className={classNames(
                                 positionCls,
                                 {'rce-mbox--clear-padding': thatAbsoluteTime},
-                                {'rce-mbox--clear-notch': !this.props.notch}
+                                {'rce-mbox--clear-notch': !this.props.notch},
+                                { 'message-focus': this.props.messageFocus},
                             )}>
                             <div
                                 className='rce-mbox-body'
@@ -187,12 +188,18 @@ export class MessageBox extends Component {
                             {
                                 this.props.notch &&
                                 (this.props.position === 'right' ?
-                                    <svg className="rce-mbox-right-notch" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20">
+                                    <svg className={classNames(
+                                        "rce-mbox-right-notch",
+                                        { 'message-focus': this.props.messageFocus},
+                                    )} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20">
                                         <path d="M0 0v20L20 0" />
                                     </svg>
                                     :
                                     <div>
-                                        <svg className="rce-mbox-left-notch" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20">
+                                        <svg className={classNames(
+                                                "rce-mbox-left-notch",
+                                                { 'message-focus': this.props.messageFocus},
+                                            )} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20">
                                             <defs>
                                                 <filter id="filter1" x="0" y="0">
                                                     <feOffset result="offOut" in="SourceAlpha" dx="-2" dy="-5" />
@@ -234,6 +241,7 @@ MessageBox.defaultProps = {
     renderAddCmp: null,
     copiableDate: false,
     onContextMenu: null,
+    messageFocus: false,
 };
 
 

--- a/src/MessageList/MessageList.js
+++ b/src/MessageList/MessageList.js
@@ -20,20 +20,7 @@ export class MessageList extends Component {
         };
 
         this.loadRef = this.loadRef.bind(this);
-        this.createReferenceOfMessage = this.createReferenceOfMessage.bind(this);
         this.onScroll = this.onScroll.bind(this);
-        this.messageRefs = [];
-    }
-
-    scrollIntoMessage(focusedMessage) {
-        var message = this.messageRefs.find(x => x.messageId === focusedMessage);
-        if (message !== undefined) {
-            this.setState({
-                messageFocus: true,
-            }, () => {
-                message.ref.scrollIntoView({block: this.props.scrollBlock, behavior: 'smooth',});
-            });
-        }
     }
 
     checkScroll() {
@@ -54,12 +41,11 @@ export class MessageList extends Component {
     componentWillReceiveProps(nextProps) {
         if (!this.mlistRef)
             return;
-        this.setState({
-            scrollBottom: this.getBottom(this.mlistRef),
-        }, this.checkScroll.bind(this));
-
-        if (nextProps.focusedMessage)
-            this.scrollIntoMessage(nextProps.focusedMessage);
+        if (nextProps.dataSource.length !== this.props.dataSource.length) {
+            this.setState({
+                scrollBottom: this.getBottom(this.mlistRef),
+            }, this.checkScroll.bind(this));
+        }
     }
 
     getBottom(e) {
@@ -96,26 +82,15 @@ export class MessageList extends Component {
             this.props.onContextMenu(item, i, e);
     }
 
+    onMessageFocused(item, i, e) {
+        if (this.props.onMessageFocused instanceof Function)
+            this.props.onMessageFocused(item, i, e);
+    }
+
     loadRef(ref) {
         this.mlistRef = ref;
         if (this.props.cmpRef instanceof Function)
             this.props.cmpRef(ref);
-    }
-
-    createReferenceOfMessage(ref, messageId) {
-        var check = this.messageRefs.find(res => res.messageId === messageId);
-
-        if (check !== undefined) {
-            var index = this.messageRefs.indexOf(check);
-            if (index !== -1) {
-                this.messageRefs.splice(index, 1);
-            }
-        }
-
-        this.messageRefs.push({
-            ref: ref,
-            messageId: messageId,
-        });
     }
 
     onScroll(e) {
@@ -163,22 +138,18 @@ export class MessageList extends Component {
                     className='rce-mlist'>
                     {
                         this.props.dataSource.map((x, i) => (
-                            <div
-                                ref={ref =>  this.createReferenceOfMessage(ref, x.id)}>
-                                <MessageBox
-                                    key={i}
-                                    {...x}
-                                    focusedMessage={this.props.focusedMessage}
-                                    messageFocus={x.id === this.props.focusedMessage && this.state.messageFocus}
-                                    onOpen={this.props.onOpen && ((e) => this.onOpen(x, i, e))}
-                                    onFocus={this.props.onFocus && ((e) => this.onFocus(x, i, e)) }
-                                    onDownload={this.props.onDownload && ((e) => this.onDownload(x, i, e))}
-                                    onTitleClick={this.props.onTitleClick && ((e) => this.onTitleClick(x, i, e))}
-                                    onForwardClick={this.props.onForwardClick && ((e) => this.onForwardClick(x, i, e))}
-                                    onClick={this.props.onClick && ((e) => this.onClick(x, i, e))}
-                                    onContextMenu={this.props.onContextMenu && ((e) => this.onContextMenu(x, i, e))}
-                                />
-                            </div>
+                            <MessageBox
+                                key={i}
+                                {...x}
+                                onMessageFocused={this.props.onMessageFocused && ((e) => this.onMessageFocused(x, i, e))}
+                                onOpen={this.props.onOpen && ((e) => this.onOpen(x, i, e))}
+                                onFocus={this.props.onFocus && ((e) => this.onFocus(x, i, e)) }
+                                onDownload={this.props.onDownload && ((e) => this.onDownload(x, i, e))}
+                                onTitleClick={this.props.onTitleClick && ((e) => this.onTitleClick(x, i, e))}
+                                onForwardClick={this.props.onForwardClick && ((e) => this.onForwardClick(x, i, e))}
+                                onClick={this.props.onClick && ((e) => this.onClick(x, i, e))}
+                                onContextMenu={this.props.onContextMenu && ((e) => this.onContextMenu(x, i, e))}
+                            />
                         ))
                     }
                 </div>
@@ -216,8 +187,6 @@ MessageList.defaultProps = {
     toBottomHeight: 300,
     downButton: true,
     downButtonBadge: null,
-    focusedMessage: null,
-    scrollBlock: 'center',
 };
 
 export default MessageList;

--- a/src/MessageList/MessageList.js
+++ b/src/MessageList/MessageList.js
@@ -1,9 +1,7 @@
 import React, { Component, } from 'react';
 import './MessageList.css';
 
-import {
-    MessageBox,
-} from '../MessageBox/MessageBox';
+import MessageBox from '../MessageBox/MessageBox';
 
 import FaChevronDown from 'react-icons/lib/fa/chevron-down';
 

--- a/src/MessageList/MessageList.js
+++ b/src/MessageList/MessageList.js
@@ -14,7 +14,6 @@ export class MessageList extends Component {
         this.state = {
             scrollBottom: 0,
             downButton: false,
-            messageFocus: false,
         };
 
         this.loadRef = this.loadRef.bind(this);
@@ -139,14 +138,13 @@ export class MessageList extends Component {
                             <MessageBox
                                 key={i}
                                 {...x}
-                                onMessageFocused={this.props.onMessageFocused && ((e) => this.onMessageFocused(x, i, e))}
                                 onOpen={this.props.onOpen && ((e) => this.onOpen(x, i, e))}
-                                onFocus={this.props.onFocus && ((e) => this.onFocus(x, i, e)) }
                                 onDownload={this.props.onDownload && ((e) => this.onDownload(x, i, e))}
                                 onTitleClick={this.props.onTitleClick && ((e) => this.onTitleClick(x, i, e))}
                                 onForwardClick={this.props.onForwardClick && ((e) => this.onForwardClick(x, i, e))}
                                 onClick={this.props.onClick && ((e) => this.onClick(x, i, e))}
                                 onContextMenu={this.props.onContextMenu && ((e) => this.onContextMenu(x, i, e))}
+                                onMessageFocused={this.props.onMessageFocused && ((e) => this.onMessageFocused(x, i, e))}
                             />
                         ))
                     }


### PR DESCRIPTION
This PR enables scrolling into MessageBox of focused message in MessageList.
focusedMessage prop of MessageList is the id of focused message. id is required for focus.

Example:

![mesage-focus](https://user-images.githubusercontent.com/30048977/59856949-8a7c2700-9380-11e9-8a06-7a02ca9dfddb.gif)