### PR TITLE
(2019-06-28) pull request by giseoplee : after 10.6 version, the scrollbar does not come down

### DIFF
--- a/src/MessageList/MessageList.js
+++ b/src/MessageList/MessageList.js
@@ -38,11 +38,10 @@ export class MessageList extends Component {
     componentWillReceiveProps(nextProps) {
         if (!this.mlistRef)
             return;
-        if (nextProps.dataSource.length !== this.props.dataSource.length) {
-            this.setState({
-                scrollBottom: this.getBottom(this.mlistRef),
-            }, this.checkScroll.bind(this));
-        }
+        
+        this.setState({
+            scrollBottom: this.getBottom(this.mlistRef),
+        }, this.checkScroll.bind(this));
     }
 
     getBottom(e) {


### PR DESCRIPTION
The length of this.props and nextProps is always the same. So this if statement hinders proper scroll bar behavior. After updating my application from 10.5 to 10.6, the scroll bar does not come down. If you have modified for other reasons, please share
So I think the MessageList component should be rolled back and request this pull request.
