### PR TITLE
Stop dates from being inverted

### DIFF
--- a/native/MessageBox/MessageBox.js
+++ b/native/MessageBox/MessageBox.js
@@ -94,7 +94,7 @@ export class MessageBox extends Component {
                                         !isNaN(this.props.date) &&
                                         (
                                             this.props.dateString ||
-                                            format(new Date(), undefined, this.props.date)
+                                            format(this.props.date)
                                         )
                                     }
                                     </Text>

--- a/src/ChatItem/ChatItem.js
+++ b/src/ChatItem/ChatItem.js
@@ -45,7 +45,7 @@ export class ChatItem extends Component {
                                     !isNaN(this.props.date) &&
                                     (
                                         this.props.dateString ||
-                                        format(new Date(), undefined, this.props.date)
+                                        format(this.props.date)
                                     )
                                 }
                             </div>

--- a/src/MessageBox/MessageBox.js
+++ b/src/MessageBox/MessageBox.js
@@ -43,7 +43,7 @@ export class MessageBox extends Component {
 
         const dateText = this.props.date && !isNaN(this.props.date) && (
             this.props.dateString ||
-            format(new Date(), undefined, this.props.date)
+            format(this.props.date)
         );
 
         return (
@@ -170,7 +170,7 @@ export class MessageBox extends Component {
                                         !isNaN(this.props.date) &&
                                         (
                                             this.props.dateString ||
-                                            format(new Date(), undefined, this.props.date)
+                                            format(this.props.date)
                                         )
                                     }
                                     {


### PR DESCRIPTION
I've changed the function call to `timeago.format` as taking `this.props.date` as the only argument.

I think the reason the dates were coming out 'backwards' as per https://github.com/Detaysoft/react-chat-elements/issues/100 was that the relative / actual dates in the three-argument implementation were the wrong way round.

Since we're not using locales (the second argument in the original function call), and the relative date is always just a new date (now), I think we can just use the single-argument version of `timeago.format`.