### PR TITLE
(Input) Allowed value props to be passed in

### DIFF
--- a/src/Input/Input.js
+++ b/src/Input/Input.js
@@ -71,7 +71,7 @@ export class Input extends Component {
                         type={this.props.type}
                         className={classNames('rce-input')}
                         placeholder={this.props.placeholder}
-                        value={this.state.value}
+                        value={this.props.value || this.state.value}
                         style={this.props.inputStyle}
                         onChange={this.onChange.bind(this)}
                         onCopy={this.props.onCopy}
@@ -95,7 +95,7 @@ export class Input extends Component {
                         type={this.props.type}
                         className={classNames('rce-input', 'rce-input-textarea')}
                         placeholder={this.props.placeholder}
-                        value={this.state.value}
+                        value={this.props.value || this.state.value}
                         style={this.props.inputStyle}
                         onChange={this.onChange.bind(this)}
                         onCopy={this.props.onCopy}


### PR DESCRIPTION
Thanks for coming up with such an awesome package!

I am using React Hooks and react hook's ref is no longer a function. So, with the current implementation, there is no way for us to update the value of the textarea in the **Input element**.

This implementation would allow users to pass in the `this.props.value` props and the `this.state.value` would be used by default if `this.props.value` is empty.

Please kindly look into my PR and merge it if you are fine with it.

Thanks!