### PR TITLE
fix: MessageBox renderAddCmp

### DIFF
--- a/src/MessageBox/MessageBox.tsx
+++ b/src/MessageBox/MessageBox.tsx
@@ -48,7 +48,7 @@ const MessageBox: React.FC<MessageBoxType> = ({ focus = false, notch = true, sty
 
   return (
     <div ref={messageRef} className={classNames('rce-container-mbox', props.className)} onClick={props.onClick}>
-      {props.renderAddCmp instanceof Function && props.renderAddCmp()}
+      {props.renderAddCmp instanceof Function ? props.renderAddCmp() : props.renderAddCmp}
       {props.type === 'system' ? (
         <SystemMessage {...props} focus={focus} notch={notch} />
       ) : (

--- a/src/type.d.ts
+++ b/src/type.d.ts
@@ -519,7 +519,7 @@ export interface ISpotifyMessageProps extends ISpotifyMessage {}
  */
 export interface IMessageBoxProps {
   onMessageFocused?: any
-  renderAddCmp?: JSX.Element
+  renderAddCmp?: JSX.Element | (() => JSX.Element)
   onClick?: React.MouseEventHandler
   onOpen?: React.MouseEventHandler
   onPhotoError?: React.MouseEventHandler


### PR DESCRIPTION
## Reason
<img width="473" alt="iShot_2023-03-02_10 36 17" src="https://user-images.githubusercontent.com/43402341/222316543-9af79343-76b9-42e6-b36d-2f73eed1e8d1.png">

This is a JSX conforming to the Type definition, but it doesn't work.
because in the code it needs to be a function 👇

<img width="887" alt="iShot_2023-03-02_10 40 00" src="https://user-images.githubusercontent.com/43402341/222317069-43ab10e3-f51a-4da3-8f52-bcc201f3b677.png">

## Resolve

Support for single jsx and jsx functions.


