### PR TITLE
NPM prepare script that allows install via git url since NPM package is out of date

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "test": "react-scripts test --env=jsdom",
     "test:coverage": "npm run test -- --coverage --collectCoverageFrom=src/**/*.js --collectCoverageFrom=!src/index.js",
     "build:lib": "yarn run build && rollup -c && yarn run move:types",
-    "prepare": "npm run build"
+    "prepare": "npm run build:lib"
   },
   "peerDependencies": {
     "react": "^18.2.0",

--- a/package.json
+++ b/package.json
@@ -78,7 +78,8 @@
     "move:types": "copyfiles -u 1 src/type.d.ts dist/",
     "test": "react-scripts test --env=jsdom",
     "test:coverage": "npm run test -- --coverage --collectCoverageFrom=src/**/*.js --collectCoverageFrom=!src/index.js",
-    "build:lib": "yarn run build && rollup -c && yarn run move:types"
+    "build:lib": "yarn run build && rollup -c && yarn run move:types",
+    "prepare": "npm run build"
   },
   "peerDependencies": {
     "react": "^18.2.0",


### PR DESCRIPTION
hello!

This PR adds an npm "prepare" script that allows the installation of library via git url. I wrote this so that I could install it via a github url since the [NPM package](https://www.npmjs.com/package/react-chat-elements) is out of date.

The prepare script is a special npm script that is executed automatically under certain conditions when the package is being installed. The prepare script gets run in the following scenarios:

- During the installation of the package as a dependency in another project via npm install. This means that when you include your fork of react-chat-elements in a project's package.json, the prepare script will be executed automatically when one installs the package with npm install.

- When you run npm pack, npm publish, or npm ci inside the package directory. In these cases, the prepare script is executed to ensure that the package is built properly before packaging or publishing it.